### PR TITLE
Add API permission for the Miniflux API endpoint

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -74,6 +74,10 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
+    api.url = "/v1"
+    api.show_tile = false
+    api.allowed = "visitors"
+    api.auth_header = false
 
     [resources.ports]
     


### PR DESCRIPTION
Add API permission for the Miniflux API endpoint

## Problem

- *Cannot access Miniflux API unless the entire app is made accessible to visitors*

## Solution

- *Add the API endpoint granularity to Yunohost permissions*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
